### PR TITLE
Feature   same attribute name over multiple entities

### DIFF
--- a/src/org/analyse/main/help/author.html
+++ b/src/org/analyse/main/help/author.html
@@ -19,6 +19,7 @@ Contributeurs :
 <li>Benjamin Gandon</li>
 <li>florida63</li>
 <li>Michael Wermeester</li>
+<li>Mehdi Chaabani</li>
 </ul>
 
 <u>Bibliothèques externes</u><br>

--- a/src/org/analyse/merise/gui/dialog/EntiteDialog.java
+++ b/src/org/analyse/merise/gui/dialog/EntiteDialog.java
@@ -5,7 +5,9 @@
  * Copyright (C) 2003 Dreux Loic
  * dreuxl@free.fr
  *
- *
+ * Modifications :
+ * Mehdi CHAABANI - 04/02/2017 
+ * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -554,9 +556,9 @@ public class EntiteDialog extends JDialog
          	    		return ;
                  	}
                  	*/
-                
-            	 data.addData(nomInfo.getText(), (String) typesInfo
-                        .getSelectedItem(), tailleInfo.getText());
+                    
+                data.addData(nomInfo.getText(), (String) typesInfo
+                        .getSelectedItem(), tailleInfo.getText(), nom.getText());
                 update();
                 nomInfo.setText("");
                 tailleInfo.setText("");

--- a/src/org/analyse/merise/gui/table/DictionnaireTable.java
+++ b/src/org/analyse/merise/gui/table/DictionnaireTable.java
@@ -10,6 +10,9 @@
  *  Date : 2009 janvier 22
  *  @auteur : Bruno Dabo <bruno.dabo@lywoonsoftware.com>
  *  
+ *  Date : 2017 Février 04
+ *  @auteur : Mehdi CHAABANI
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -174,7 +177,7 @@ public class DictionnaireTable extends AbstractTableModel
         addNewLine();
     }
 
-    public void addData(String nom, String type, String taille)
+    public void addData(String nom, String type, String taille, String entity)
     {
         Integer tailleInt;
 
@@ -187,11 +190,11 @@ public class DictionnaireTable extends AbstractTableModel
         if (!contains(Utilities.normaliseString(nom, Constantes.LOWER))) {
             Object[] tab = new Object[6];
             tab[0] = nom;
-            tab[1] = Utilities.normaliseString(nom,Constantes.LOWER);
+            tab[1] = Utilities.normaliseString(nom,Constantes.LOWER) + "_" + entity;
             tab[2] = type;
             tab[3] = tailleInt;
             tab[4] = new Boolean(false);
-            tab[5] = "";
+            tab[5] = entity;
             rows.set(rows.size()-1, tab);
             addNewLine();
         }
@@ -250,9 +253,9 @@ public class DictionnaireTable extends AbstractTableModel
      */
     public boolean contains(String code)
     {
-        for (int i = 0; i < rows.size(); i++)
+        /*for (int i = 0; i < rows.size(); i++)
             if (code.equals((String) (rows.get(i)[1])))
-                return true;
+                return true;*/
         return false;
     }
 

--- a/src/org/analyse/merise/mcd/composant/MPDComponent.java
+++ b/src/org/analyse/merise/mcd/composant/MPDComponent.java
@@ -7,6 +7,8 @@
  *  -------------
  *  Date : 2009 janvier 22
  *  @auteur : Bruno Dabo <bruno.dabo@lywoonsoftware.com>
+ *  Date : 2017 Février 04
+ *  @auteur : Mehdi CHAABANI
  *   
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -120,7 +122,7 @@ public class MPDComponent extends ZGraphique {
      * Construit les requêtes SQL.
      */
     public void buildSQL(DictionnaireTable data, SQLCommand sql) {
-        String text, info ;
+        String text, info, info_wid ; //info_wid: permet le traitement des attributs non typés comme clefs
         MPDEntite ent;
         int cmp, nbId;
 
@@ -154,7 +156,8 @@ public class MPDComponent extends ZGraphique {
             for (Iterator<String> e2 = ent.elementsInformations(); e2.hasNext(); cmp++) {
 
                 info = (String) (e2.next());
-
+    		info_wid  = info;
+		    
                 if (premierefois) {  // ajout des relations reflexives
                     premierefois = false;
                     defautType = (String) data.getValue(info, DictionnaireTable.TYPE);
@@ -194,21 +197,26 @@ public class MPDComponent extends ZGraphique {
                 	 */
                 	
                     if ("INT_AUTO_INCREMENT".equals(type)) {
+			info = Utilities.normaliseString(info, Constantes.LOWER);
                         type = Constantes.INT_AUTO_INCREMENT ;  // Bug #567501
                     }
                     if ("BIGINT_AUTO_INCREMENT".equals(type)) {
+			info = Utilities.normaliseString(info, Constantes.LOWER);
                         type = Constantes.BIGINT_AUTO_INCREMENT;  // Bug #567501
                     }
                 } else {
+			info = String.valueOf(data.getValue(info_wid, DictionnaireTable.NAME));
                     if ("BIGINT_AUTO_INCREMENT".equals(type)) {
-                        type = "BIGINT";
+                        info = Utilities.normaliseString(info_wid, Constantes.LOWER);
+			type = "BIGINT";
                     }   // evite de se retrouver avec AUTO_INCREMENT sur une clé étrangère
                     if ("INT_AUTO_INCREMENT".equals(type)) {
-                        type = "INT";
+                        info = Utilities.normaliseString(info_wid, Constantes.LOWER);
+			type = "INT";
                     }   // evite de se retrouver avec AUTO_INCREMENT sur une clé étrangère
                 }
                 
-                info = Utilities.normaliseString(info, Constantes.LOWER);  // Bug #622229
+                //info = Utilities.normaliseString(info, Constantes.LOWER);  // Bug #622229
                 text += info + " " + type;
 
                 try {
@@ -237,7 +245,7 @@ public class MPDComponent extends ZGraphique {
 
                         if (ent.getForeignKey(info) != null) // on a affaire à une clé étrangère
                         {
-                            text += " NOT NULL";
+                            //text += " NOT NULL";
                         }
                     }
                 }
@@ -285,6 +293,7 @@ public class MPDComponent extends ZGraphique {
 
 
         info = "";
+	info_wid ="";
         for (Iterator<ZElement> e = enumElements(); e.hasNext();) {
            
             ent = (MPDEntite) (e.next());


### PR DESCRIPTION
MCD + Dictionnaire de données :
Il est maintenant possible d'avoir le même nom d'attribut sur plusieurs entités.

MPD + Script SQL :
Les clefs primaires et étrangères, typées sur BIGINT_AUTO_INCREMENT et INT_AUTO_INCREMENT,
sont automatiquement renommées : "NomClef_NomEntitéPropriétaire"
