### PR TITLE
Correction du bug #848936 (flèches de MPD "partielles")

### DIFF
--- a/src/org/analyse/merise/mcd/composant/MPDLien.java
+++ b/src/org/analyse/merise/mcd/composant/MPDLien.java
@@ -158,36 +158,39 @@ public class MPDLien extends ZLien {
 	 * Evite d'avoir des lignes de travers.
 	 */
 	public void updateLocation() {
-		super.updateLocation();
+        super.updateLocation();
+        if (getElement( Constantes.MCDENTITE2 ).getX() > getElement( Constantes.MCDENTITE1 ).getX()
+                + getElement( Constantes.MCDENTITE1 ).getHeight()
+                || getElement( Constantes.MCDENTITE2 ).getX() + getElement( Constantes.MCDENTITE2 ).getWidth() < getElement(Constantes.MCDENTITE1 ).getX()) {
+            if (getElement( Constantes.MCDENTITE2 ).getY() < getElement( Constantes.MCDENTITE1 ).getY()
+                    + getElement( Constantes.MCDENTITE1 ).getWidth()
+                    && getElement( Constantes.MCDENTITE1 ).getY() < getElement( Constantes.MCDENTITE2 ).getY()
+                            + getElement( Constantes.MCDENTITE2 ).getHeight()) {
+                if (y2 > getElement( Constantes.MCDENTITE1 ).getY() + getElement( Constantes.MCDENTITE1 ).getHeight())
+                    y2 = getElement( Constantes.MCDENTITE1 ).getY()+ getElement( Constantes.MCDENTITE1 ).getHeight();
+                else if (y2 < getElement( Constantes.MCDENTITE1 ).getY())
+                    y2 = getElement( Constantes.MCDENTITE1 ).getY();
+                y1 = y2;
+                                if(y2 < getElement( Constantes.MCDENTITE2 ).getY()){
+                                    y2 = getElement( Constantes.MCDENTITE2 ).getY() + (getElement( Constantes.MCDENTITE2 ).getHeight()/2);
+                                }
+            }
+                } else if (getElement( Constantes.MCDENTITE2 ).getY() > getElement( Constantes.MCDENTITE1 ).getY()
+                + getElement( Constantes.MCDENTITE1 ).getWidth()
+                || getElement( Constantes.MCDENTITE2 ).getY() + getElement( Constantes.MCDENTITE2 ).getHeight() < getElement(Constantes.MCDENTITE1 ).getY()) {
+            if (getElement( Constantes.MCDENTITE2 ).getX() < getElement( Constantes.MCDENTITE1 ).getX()
+                    + getElement( Constantes.MCDENTITE1 ).getHeight()
+                    && getElement( Constantes.MCDENTITE1 ).getX() < getElement( Constantes.MCDENTITE2 ).getX()
+                            + getElement( Constantes.MCDENTITE2 ).getWidth()) {
+                if (x2 > getElement( Constantes.MCDENTITE1 ).getX() + getElement( Constantes.MCDENTITE1 ).getWidth())
+                    x2 = getElement( Constantes.MCDENTITE1 ).getX() + getElement( Constantes.MCDENTITE1 ).getWidth();
+                else if (x2 < getElement( Constantes.MCDENTITE1 ).getX())
+                    x2 = getElement( Constantes.MCDENTITE1 ).getX();
+                x1 = x2;
+            }
+        }
+    }
 
-		if (getElement(  Constantes.MCDENTITE2 ).getX() > getElement(  Constantes.MCDENTITE1 ).getX()
-				+ getElement(  Constantes.MCDENTITE1 ).getWidth()
-				|| getElement( Constantes.MCDENTITE2 ).getX() + getElement( Constantes.MCDENTITE2 ).getWidth() < getElement( Constantes.MCDENTITE1 ).getX()) {
-			if (getElement( Constantes.MCDENTITE1 ).getY() < getElement( Constantes.MCDENTITE1 ).getY()
-					+ getElement( Constantes.MCDENTITE1 ).getHeight()
-					&& getElement( Constantes.MCDENTITE1 ).getY() < getElement( Constantes.MCDENTITE2 ).getY()
-							+ getElement( Constantes.MCDENTITE2 ).getHeight()) {
-				if (y2 > getElement(  Constantes.MCDENTITE1 ).getY() + getElement( Constantes.MCDENTITE1 ).getHeight())
-					y2 = getElement( Constantes.MCDENTITE1 ).getY() + getElement( Constantes.MCDENTITE1 ).getHeight();
-				else if (y2 < getElement( Constantes.MCDENTITE1 ).getY())
-					y2 = getElement( Constantes.MCDENTITE1 ).getY();
-				y1 = y2;
-			}
-		} else if (getElement( Constantes.MCDENTITE2 ).getY() > getElement( Constantes.MCDENTITE1 ).getY()
-				+ getElement( Constantes.MCDENTITE1 ).getWidth()
-				|| getElement( Constantes.MCDENTITE2 ).getY() + getElement( Constantes.MCDENTITE2 ).getHeight() < getElement(Constantes.MCDENTITE1 ).getY()) {
-			if (getElement( Constantes.MCDENTITE2 ).getX() < getElement( Constantes.MCDENTITE1 ).getX()
-					+ getElement( Constantes.MCDENTITE1 ).getHeight()
-					&& getElement( Constantes.MCDENTITE1 ).getX() < getElement( Constantes.MCDENTITE2 ).getX()
-							+ getElement( Constantes.MCDENTITE2 ).getWidth()) {
-				if (x2 > getElement( Constantes.MCDENTITE1 ).getX() + getElement( Constantes.MCDENTITE1 ).getWidth())
-					x2 = getElement( Constantes.MCDENTITE1 ).getY() + getElement( Constantes.MCDENTITE1 ).getWidth();
-				else if (x2 < getElement( Constantes.MCDENTITE1 ).getX())
-					x2 = getElement( Constantes.MCDENTITE1 ).getX();
-				x1 = x2;
-			}
-		}
-	}
 
 	public String toString() {
 		return "MCDLien, " + info();


### PR DESCRIPTION
Correction du bug #848936 (flèches de MPD "partielles"), les flèches du mpd ne rejoignait pas l'association lorsque les entités se trouvait dans sont coin supérieur droit ou gauche.

page de référence du bug:  
https://bugs.launchpad.net/analysesi/+bug/848936

fichier .asi de test join
[exemple_bug_lien_MPD.zip](https://github.com/AnalyseSI/AnalyseSI/files/3231353/exemple_bug_lien_MPD.zip)

